### PR TITLE
Response headers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,8 @@ Django Settings
 
 The following settings can be used:
 
+.. code:: python
+
     # the version to use for ASSET VERSIONING
     INERTIA_VERSION # default: "unversioned"
 
@@ -56,6 +58,8 @@ The following settings can be used:
     INERTIA_AUTH_REDIRECT_URL_NAME # default: None
 
 Non-inertia settings:
+
+.. code:: python
 
     # To use inertia as it is with Laravel and Rails you should be using
     # Session Authentication

--- a/drf_inertia/negotiation.py
+++ b/drf_inertia/negotiation.py
@@ -15,6 +15,10 @@ REDIRECTS = [
 ]
 
 
+def is_valid_inertia_response(status_code):
+    return status_code == status.HTTP_409_CONFLICT or status_code < 300
+
+
 class Inertia(object):
     is_data = False  # is the X-Inertia header present
     version = None
@@ -82,6 +86,13 @@ class InertiaRendererMixin(object):
             renderer_context["request"].inertia.data = data
             serializer = InertiaSerializer(renderer_context["request"].inertia, context=renderer_context)
             data = serializer.data
+
+            # add response headers
+            renderer_context["response"]["X-Inertia-Version"] = VERSION
+
+            # Only add X-Inertia header on 2XX and 409 responses
+            if is_valid_inertia_response(renderer_context["response"].status_code):
+                renderer_context["response"]["X-Inertia"] = "true"
 
         return super(InertiaRendererMixin, self).render(
             data, accepted_media_type=accepted_media_type, renderer_context=renderer_context)

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -50,6 +50,7 @@ class DecoratorTestCase(TestCase):
         assert data["component"] == "Component/Path"
         assert response.status_code == 200
         assert response['Content-Type'] == "application/json"
+        assert response['X-Inertia'] == "true"
 
     def test_api_view_class_decorated(self):
         @inertia("Component/Path")
@@ -67,6 +68,7 @@ class DecoratorTestCase(TestCase):
         assert data["component"] == "Component/Path"
         assert response.status_code == 200
         assert response['Content-Type'] == "application/json"
+        assert response['X-Inertia'] == "true"
 
     def test_component_method_decorated(self):
         @inertia("Component/Path")
@@ -85,6 +87,7 @@ class DecoratorTestCase(TestCase):
         assert data["component"] == "Component/Other"
         assert response.status_code == 200
         assert response['Content-Type'] == "application/json"
+        assert response['X-Inertia'] == "true"
 
     def test_viewset_decorated(self):
         @inertia("Action/List")
@@ -106,6 +109,29 @@ class DecoratorTestCase(TestCase):
         assert data["props"]["view"] == "list"
         assert response.status_code == 200
         assert response['Content-Type'] == "application/json"
+        assert response['X-Inertia'] == "true"
+
+    def test_viewset_decorated_diff(self):
+        @inertia("Action/List", list="Action/List2")
+        class ActionViewSet(GenericViewSet):
+            queryset = Action.objects.all()
+
+            def list(self, request, *args, **kwargs):
+                response = Response(data={"view": "list"})
+                return response
+
+        request = self.factory.get('/', HTTP_X_INERTIA=True)
+        response = ActionViewSet.as_view({'get': 'list'})(request)
+        data = json.loads(response.rendered_content)
+        assert "component" in data
+        assert "props" in data
+        assert "url" in data
+        assert "version" in data
+        assert data["component"] == "Action/List2"
+        assert data["props"]["view"] == "list"
+        assert response.status_code == 200
+        assert response['Content-Type'] == "application/json"
+        assert response["X-Inertia"] == "true"
 
     def test_decorated_api_view_handles_error(self):
         @inertia("Component/Path")


### PR DESCRIPTION
Add inertia response headers in the render method. Only adds X-Inertia if response is `2XX` or `409`. Need to do this in render when the `status_code` becomes available

Also changed from wrapping `initialize_request` to `initial` because it is less likely to be overridden.